### PR TITLE
Add download_dir argument to vllm

### DIFF
--- a/libs/langchain/langchain/llms/vllm.py
+++ b/libs/langchain/langchain/llms/vllm.py
@@ -62,6 +62,11 @@ class VLLM(BaseLLM):
     dtype: str = "auto"
     """The data type for the model weights and activations."""
 
+    download_dir: Optional[str] = None
+    """Directory to download and load the weights. (Default to the default 
+    cache dir of huggingface)"""
+
+
     client: Any  #: :meta private:
 
     @root_validator()
@@ -81,6 +86,7 @@ class VLLM(BaseLLM):
             tensor_parallel_size=values["tensor_parallel_size"],
             trust_remote_code=values["trust_remote_code"],
             dtype=values["dtype"],
+            download_dir=values["download_dir"],
         )
 
         return values


### PR DESCRIPTION
- Description:
Add a 'download_dir' argument to VLLM model (to change the cache download directotu when retrieving a model from HF hub)
- Issue:
On some remote machine, I want the cache dir to be in a volume where I have space (models are heavy nowadays). Sometimes the default HF cache dir might not be what we want.
- Dependencies:
None